### PR TITLE
Update deps, fix test runner, update error messages to use named params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 node_modules
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.gitmodules
-.npmignore
-node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
-
 sudo: false
-
 node_js:
-  - 0.8
-  - 0.10
-  - 0.12
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+before_install:
+  - npm i -g npm

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -41,19 +41,22 @@
         }
 
         var sf = sinon.spy.formatters;
-        var spyValues = function (spy) { return [spy, sf.c(spy), sf.C(spy)]; };
 
         referee.add("called", {
             assert: function (spy) {
                 verifyFakes.call(this, spy);
                 return spy.called;
             },
-            assertMessage: "Expected ${0} to be called at least once but was " +
-                "never called",
-            refuteMessage: "Expected ${0} to not be called but was called " +
-                "${1}${2}",
+            assertMessage: "Expected ${spyObj} to be called at least once but was never called",
+            refuteMessage: "Expected ${spyObj} to not be called but was called ${times}${calls}",
             expectation: "toHaveBeenCalled",
-            values: spyValues
+            values: function (spyObj) {
+                return {
+                    spyObj: spyObj,
+                    times: sf.c(spyObj),
+                    calls: sf.C(spyObj)
+                };
+            }
         });
 
         function slice(arr, from, to) {
@@ -78,25 +81,27 @@
                 this.actual = sinon.orderByFirstCall(slice(args)).join(", ");
             },
 
-            assertMessage: "Expected ${expected} to be called in order but " +
-                "were called as ${actual}",
+            assertMessage: "Expected ${expected} to be called in order but were called as ${actual}",
             refuteMessage: "Expected ${expected} not to be called in order"
         });
 
         function addCallCountAssertion(count) {
-            var c = count.toLowerCase();
-
             referee.add("called" + count, {
                 assert: function (spy) {
                     verifyFakes.call(this, spy);
                     return spy["called" + count];
                 },
-                assertMessage: "Expected ${0} to be called " + c +
-                    " but was called ${1}${2}",
-                refuteMessage: "Expected ${0} to not be called exactly " +
-                    c + "${2}",
+                assertMessage: "Expected ${spyObj} to be called ${expectedTimes} but was called ${times}${calls}",
+                refuteMessage: "Expected ${spyObj} to not be called exactly ${expectedTimes}${calls}",
                 expectation: "toHaveBeenCalled" + count,
-                values: spyValues
+                values: function (spyObj) {
+                    return {
+                        spyObj: spyObj,
+                        expectedTimes: count.toLowerCase(),
+                        times: sf.c(spyObj),
+                        calls: sf.C(spyObj)
+                    };
+                }
             });
         }
 
@@ -104,8 +109,12 @@
         addCallCountAssertion("Twice");
         addCallCountAssertion("Thrice");
 
-        function valuesWithThis(spy, thisObj) {
-            return [spy, thisObj, (spy.printf && spy.printf("%t")) || ""];
+        function valuesWithThis(spyObj, expectedThis) {
+            return {
+                spyObj: spyObj,
+                expectedThis: expectedThis,
+                actualThis: (spyObj.printf ? spyObj.printf("%t") : "")
+            };
         }
 
         referee.add("calledOn", {
@@ -113,9 +122,8 @@
                 verifyFakes.call(this, spy);
                 return spy.calledOn(thisObj);
             },
-            assertMessage: "Expected ${0} to be called with ${1} as this but " +
-                "was called on ${2}",
-            refuteMessage: "Expected ${0} not to be called with ${1} as this",
+            assertMessage: "Expected ${spyObj} to be called with ${expectedThis} as this but was called on ${actualThis}",
+            refuteMessage: "Expected ${spyObj} not to be called with ${expectedThis} as this",
             expectation: "toHaveBeenCalledOn",
             values: valuesWithThis
         });
@@ -125,10 +133,8 @@
                 verifyFakes.call(this, spy);
                 return spy.alwaysCalledOn(thisObj);
             },
-            assertMessage: "Expected ${0} to always be called with ${1} as " +
-                "this but was called on ${2}",
-            refuteMessage: "Expected ${0} not to always be called with ${1} " +
-                "as this",
+            assertMessage: "Expected ${spyObj} to always be called with ${expectedThis} as this but was called on ${actualThis}",
+            refuteMessage: "Expected ${spyObj} not to always be called with ${expectedThis} as this",
             expectation: "toHaveAlwaysBeenCalledOn",
             values: valuesWithThis
         });
@@ -138,16 +144,17 @@
             for (l = args.length, result = []; i < l; ++i) {
                 result.push(sinon.format(args[i]));
             }
-
             return result.join(", ");
         }
 
-        function spyAndCalls(spy) {
-            return [
-                spy,
-                formattedArgs(arguments, 1),
-                spy.printf && spy.printf("%C")
-            ];
+        function spyAndCalls(spyObj) {
+            var expected = formattedArgs(arguments, 1);
+            var actual = spyObj.printf ? spyObj.printf("%C") : "";
+            return {
+                spyObj: spyObj,
+                actual: actual,
+                expected: expected
+            }
         }
 
         referee.add("calledWith", {
@@ -155,9 +162,8 @@
                 verifyFakes.call(this, spy);
                 return spy.calledWith.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to be called with arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to be called with arguments " +
-                "${1}${2}",
+            assertMessage: "Expected ${spyObj} to be called with arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to be called with arguments ${expected}${actual}",
             expectation: "toHaveBeenCalledWith",
             values: spyAndCalls
         });
@@ -167,10 +173,8 @@
                 verifyFakes.call(this, spy);
                 return spy.alwaysCalledWith.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to always be called with " +
-                "arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to always be called with " +
-                "arguments${1}${2}",
+            assertMessage: "Expected ${spyObj} to always be called with arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to always be called with arguments ${expected}${actual}",
             expectation: "toHaveAlwaysBeenCalledWith",
             values: spyAndCalls
         });
@@ -181,10 +185,8 @@
                 return spy.calledOnce &&
                     spy.calledWith.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to be called once with " +
-                "arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to be called once with " +
-                "arguments ${1}${2}",
+            assertMessage: "Expected ${spyObj} to be called once with arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to be called once with arguments ${expected}${actual}",
             expectation: "toHaveBeenCalledOnceWith",
             values: spyAndCalls
         });
@@ -194,10 +196,8 @@
                 verifyFakes.call(this, spy);
                 return spy.calledWithExactly.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to be called with exact " +
-                "arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to be called with exact " +
-                "arguments${1}${2}",
+            assertMessage: "Expected ${spyObj} to be called with exact arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to be called with exact arguments ${expected}${actual}",
             expectation: "toHaveBeenCalledWithExactly",
             values: spyAndCalls
         });
@@ -205,13 +205,10 @@
         referee.add("alwaysCalledWithExactly", {
             assert: function (spy) {
                 verifyFakes.call(this, spy);
-                return spy.alwaysCalledWithExactly.apply(spy,
-                    slice(arguments, 1));
+                return spy.alwaysCalledWithExactly.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to always be called with exact " +
-                "arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to always be called with exact " +
-                "arguments${1}${2}",
+            assertMessage: "Expected ${spyObj} to always be called with exact arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to always be called with exact arguments ${expected}${actual}",
             expectation: "toHaveAlwaysBeenCalledWithExactly",
             values: spyAndCalls
         });
@@ -221,10 +218,8 @@
                 verifyFakes.call(this, spy);
                 return spy.calledWithMatch.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to be called with matching " +
-                "arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to be called with matching " +
-                "arguments${1}${2}",
+            assertMessage: "Expected ${spyObj} to be called with matching arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to be called with matching arguments ${expected}${actual}",
             expectation: "toHaveBeenCalledWithMatch",
             values: spyAndCalls
         });
@@ -232,19 +227,20 @@
         referee.add("alwaysCalledWithMatch", {
             assert: function (spy) {
                 verifyFakes.call(this, spy);
-                return spy.alwaysCalledWithMatch.apply(spy,
-                    slice(arguments, 1));
+                return spy.alwaysCalledWithMatch.apply(spy, slice(arguments, 1));
             },
-            assertMessage: "Expected ${0} to always be called with matching " +
-                "arguments ${1}${2}",
-            refuteMessage: "Expected ${0} not to always be called with " +
-                "matching arguments${1}${2}",
+            assertMessage: "Expected ${spyObj} to always be called with matching arguments ${expected}${actual}",
+            refuteMessage: "Expected ${spyObj} not to always be called with matching arguments ${expected}${actual}",
             expectation: "toHaveAlwaysBeenCalledWithMatch",
             values: spyAndCalls
         });
 
-        function spyAndException(spy, exception) {
-            return [spy, spy.printf && spy.printf("%C")];
+        function spyAndException(spyObj, exception) {
+            return {
+                spyObj: spyObj,
+                actual: spyObj.printf ? spyObj.printf("%C") : "",
+                exception: exception // note: not actually used
+            };
         }
 
         referee.add("threw", {
@@ -252,8 +248,8 @@
                 verifyFakes.call(this, spy);
                 return spy.threw(arguments[1]);
             },
-            assertMessage: "Expected ${0} to throw an exception${1}",
-            refuteMessage: "Expected ${0} not to throw an exception${1}",
+            assertMessage: "Expected ${spyObj} to throw an exception${actual}",
+            refuteMessage: "Expected ${spyObj} not to throw an exception${actual}",
             expectation: "toHaveThrown",
             values: spyAndException
         });
@@ -263,8 +259,8 @@
                 verifyFakes.call(this, spy);
                 return spy.alwaysThrew(arguments[1]);
             },
-            assertMessage: "Expected ${0} to always throw an exception${1}",
-            refuteMessage: "Expected ${0} not to always throw an exception${1}",
+            assertMessage: "Expected ${spyObj} to always throw an exception${actual}",
+            refuteMessage: "Expected ${spyObj} not to always throw an exception${actual}",
             expectation: "toAlwaysHaveThrown",
             values: spyAndException
         });

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
         "test-debug": "node --debug-brk run-tests.js"
     },
     "devDependencies": {
-        "buster-test": "*",
-        "formatio": "*",
-        "referee": "~0.11",
-        "sinon": ">=1.4"
+        "buster-test": "0.7.x",
+        "formatio": "1.x",
+        "referee": "1.x",
+        "sinon": "1.x"
     }
 }

--- a/test/referee-sinon-test.js
+++ b/test/referee-sinon-test.js
@@ -41,10 +41,14 @@ function requiresSpy(assertion) {
 }
 
 var testCase = buster.testCase("referee-sinon", {
+    tearDown: function () {
+        if (referee.format.restore) { referee.format.restore(); }
+        if (referee.fail.restore) { referee.fail.restore(); }
+        if (assert.calledWithMatch.restore) { assert.calledWithMatch.restore(); }
+        if (assert.alwaysCalledWithMatch.restore) { assert.alwaysCalledWithMatch.restore(); }
+    },
+
     "assertions": {
-        tearDown: function () {
-            if (referee.format.restore) { referee.format.restore(); }
-        },
 
         "formats assert messages through referee": function () {
             sinon.stub(referee, "format").returns("I'm the object");
@@ -502,10 +506,7 @@ var testCase = buster.testCase("referee-sinon", {
                 assert.calledOnce(sinon.spy());
             } catch (e) {}
 
-            var called = referee.fail.calledOnce;
-            referee.fail.restore();
-
-            assert(called);
+            assert(referee.fail.calledOnce);
         }
     },
 
@@ -531,10 +532,7 @@ var testCase = buster.testCase("referee-sinon", {
                 sinon.mock().never()();
             } catch (e) {}
 
-            var called = referee.fail.calledOnce;
-            referee.fail.restore();
-
-            assert(called);
+            assert(referee.fail.calledOnce);
         }
     },
 

--- a/test/referee-sinon-test.js
+++ b/test/referee-sinon-test.js
@@ -16,17 +16,13 @@ function requiresFunction(assertion) {
     var args = [32].concat([].slice.call(arguments, 1));
 
     return function () {
-        try {
+        assert.exception(function () {
             assert[assertion].apply(assert, args);
-        } catch (e) {
-            assert.match(e.message, "32 is not a function");
-        }
+        }, {message: "32 is not a function"});
 
-        try {
+        assert.exception(function () {
             refute[assertion].apply(assert, args);
-        } catch (err) {
-            assert.match(err.message, "32 is not a function");
-        }
+        }, {message: "32 is not a function"});
     };
 }
 
@@ -34,17 +30,13 @@ function requiresSpy(assertion) {
     var args = [function () {}].concat([].slice.call(arguments, 1));
 
     return function () {
-        try {
+        assert.exception(function () {
             assert[assertion].apply(assert, args);
-        } catch (e) {
-            assert.match(e.message, "is not stubbed");
-        }
+        }, {message: "is not stubbed"});
 
-        try {
+        assert.exception(function () {
             refute[assertion].apply(assert, args);
-        } catch (err) {
-            assert.match(err.message, "is not stubbed");
-        }
+        }, {message: "is not stubbed"});
     };
 }
 
@@ -91,7 +83,7 @@ var testCase = buster.testCase("referee-sinon", {
                     var message = "[assert.calledWith] Expected function " +
                             "spy() {} to be called with arguments null, 2, 2" +
                             "\n    spy(null, 1, 2)";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             },
 
@@ -129,7 +121,7 @@ var testCase = buster.testCase("referee-sinon", {
                     var message = "[assert.calledWithExactly] Expected " +
                             "function spy() {} to be called with exact " +
                             "arguments null, 2, 2\n    spy(null, 1, 2)";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -156,7 +148,7 @@ var testCase = buster.testCase("referee-sinon", {
                     var message = "[assert.calledWithMatch] Expected " +
                             "function spy() {} to be called with matching " +
                             "arguments { check: 321 }\n    spy({ check: 123 })";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -185,9 +177,12 @@ var testCase = buster.testCase("referee-sinon", {
                 } catch (e) {
                     var message = "[assert.alwaysCalledWithMatch] Expected " +
                             "function spy() {} to always be called with " +
-                            "matching arguments { check: 321 }\n    spy({ " +
-                            "check: 123 })\n    spy({ check: 321 })";
-                    assert.equals(e.message, message);
+                            "matching arguments { check: 321 }";
+                    assert.match(e.message, message);
+                    var lines = e.message.split("\n");
+                    assert.equals(lines.length, 3);
+                    assert.match(lines[1], "    spy({ check: 123 })");
+                    assert.match(lines[2], "    spy({ check: 321 })");
                 }
             }
         },
@@ -210,7 +205,7 @@ var testCase = buster.testCase("referee-sinon", {
                 } catch (e) {
                     var message = "[assert.calledOnce] Expected function " +
                             "spy() {} to be called once but was called 0 times";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -355,7 +350,7 @@ var testCase = buster.testCase("referee-sinon", {
                     var message = "[assert.alwaysCalledWith] Expected " +
                             "function spy() {} to always be called with " +
                             "arguments 12\n    spy(42)";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -383,7 +378,7 @@ var testCase = buster.testCase("referee-sinon", {
                     var message = "[assert.alwaysCalledWithExactly] Expected " +
                             "function spy() {} to always be called with " +
                             "exact arguments null, 2, 2\n    spy(null, 1, 2)";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -406,7 +401,7 @@ var testCase = buster.testCase("referee-sinon", {
                 } catch (e) {
                     var message = "[assert.threw] Expected function spy() " +
                             "{} to throw an exception";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -430,7 +425,7 @@ var testCase = buster.testCase("referee-sinon", {
                 } catch (e) {
                     var message = "[assert.alwaysThrew] Expected function " +
                             "spy() {} to always throw an exception";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         },
@@ -476,7 +471,7 @@ var testCase = buster.testCase("referee-sinon", {
                     var message = "[assert.calledOnceWith] Expected function " +
                             "spy() {} to be called once with arguments 12\n" +
                             "    spy(42)";
-                    assert.equals(e.message, message);
+                    assert.match(e.message, message);
                 }
             }
         }

--- a/test/referee-sinon-test.js
+++ b/test/referee-sinon-test.js
@@ -560,9 +560,11 @@ var testCase = buster.testCase("referee-sinon", {
 
 var runner = buster.testRunner.create();
 referee.on("pass", runner.assertionPass.bind(runner));
-var reporter = buster.reporters.defaultReporter.create({
-    color: true,
-    bright: true
-}).listen(runner);
+buster.reporters.specification
+    .create({
+        color: true,
+        bright: true
+    })
+    .listen(runner);
 
 runner.runSuite([testCase]);


### PR DESCRIPTION
Progress for https://github.com/busterjs/buster/issues/463

I'll wait for fully updated `buster-test` and `referee` to be on npm before I merge this.